### PR TITLE
テンプレートプロジェクトの frontend と backend のネットワークを統合

### DIFF
--- a/templates/vite-rust/docker/backend/api/compose.yml
+++ b/templates/vite-rust/docker/backend/api/compose.yml
@@ -48,15 +48,15 @@ services:
     tty: true
     stdin_open: true
     networks:
-      - dev-{{ project_name | kebab_case }}-backend-network
+      - dev-{{ project_name | kebab_case }}-network
     profiles:
       - dev
       - dev-{{ project_name | kebab_case }}
       - dev-{{ project_name | kebab_case }}-backend
 
 networks:
-  dev-{{ project_name | kebab_case }}-backend-network:
-    name: dev-{{ project_name | kebab_case }}-backend-network
+  dev-{{ project_name | kebab_case }}-network:
+    name: dev-{{ project_name | kebab_case }}-network
 
 volumes:
   dev-{{ project_name | kebab_case }}-backend-target-volume:

--- a/templates/vite-rust/docker/backend/batch/compose.yml
+++ b/templates/vite-rust/docker/backend/batch/compose.yml
@@ -47,7 +47,7 @@ services:
     tty: true
     stdin_open: true
     networks:
-      - dev-{{ project_name | kebab_case }}-backend-network
+      - dev-{{ project_name | kebab_case }}-network
     profiles:
       - dev
       - dev-{{ project_name | kebab_case }}
@@ -55,7 +55,7 @@ services:
 
 networks:
   dev-{{ project_name | kebab_case }}-backend-network:
-    name: dev-{{ project_name | kebab_case }}-backend-network
+    name: dev-{{ project_name | kebab_case }}-network
 
 volumes:
   dev-{{ project_name | kebab_case }}-backend-target-volume:

--- a/templates/vite-rust/docker/backend/rdb-replica/compose.yml
+++ b/templates/vite-rust/docker/backend/rdb-replica/compose.yml
@@ -44,7 +44,7 @@ services:
     tty: true
     stdin_open: true
     networks:
-      - dev-{{ project_name | kebab_case }}-backend-network
+      - dev-{{ project_name | kebab_case }}-network
     profiles:
       - dev
       - dev-{{ project_name | kebab_case }}
@@ -61,8 +61,8 @@ services:
       start_period: 30s
 
 networks:
-  dev-{{ project_name | kebab_case }}-backend-network:
-    name: dev-{{ project_name | kebab_case }}-backend-network
+  dev-{{ project_name | kebab_case }}-network:
+    name: dev-{{ project_name | kebab_case }}-network
 
 volumes:
   dev-{{ project_name | kebab_case }}-backend-rdb-replica-volume:

--- a/templates/vite-rust/docker/backend/rdb/compose.yml
+++ b/templates/vite-rust/docker/backend/rdb/compose.yml
@@ -42,7 +42,7 @@ services:
     tty: true
     stdin_open: true
     networks:
-      - dev-{{ project_name | kebab_case }}-backend-network
+      - dev-{{ project_name | kebab_case }}-network
     profiles:
       - dev
       - dev-{{ project_name | kebab_case }}
@@ -59,8 +59,8 @@ services:
       start_period: 30s
 
 networks:
-  dev-{{ project_name | kebab_case }}-backend-network:
-    name: dev-{{ project_name | kebab_case }}-backend-network
+  dev-{{ project_name | kebab_case }}-network:
+    name: dev-{{ project_name | kebab_case }}-network
 
 volumes:
   dev-{{ project_name | kebab_case }}-backend-rdb-volume:

--- a/templates/vite-rust/docker/frontend/vite/compose.yml
+++ b/templates/vite-rust/docker/frontend/vite/compose.yml
@@ -48,15 +48,15 @@ services:
     tty: true
     stdin_open: true
     networks:
-      - dev-{{ project_name | kebab_case }}-frontend-network
+      - dev-{{ project_name | kebab_case }}-network
     profiles:
       - dev
       - dev-{{ project_name | kebab_case }}
       - dev-{{ project_name | kebab_case }}-frontend
 
 networks:
-  dev-{{ project_name | kebab_case }}-frontend-network:
-    name: dev-{{ project_name | kebab_case }}-frontend-network
+  dev-{{ project_name | kebab_case }}-network:
+    name: dev-{{ project_name | kebab_case }}-network
 
 volumes:
   dev-{{ project_name | kebab_case }}-frontend-node-modules-volume:


### PR DESCRIPTION
- クラ・鯖で分ける必要性がなかったため、プロジェクトレベルで分離されていれば問題ないと判断