### PR TITLE
Rust の target triple が target tuple の名称に変更になったので差し替え

### DIFF
--- a/templates/bash-util/lib/core.sh
+++ b/templates/bash-util/lib/core.sh
@@ -54,7 +54,7 @@ function core::hostname() {
   uname -n
 }
 
-function core::target_triple() {
+function core::target_tuple() {
 
   # NOTE: rust installer inspired
   if ! command -v 'uname' &>/dev/null; then

--- a/templates/bash-util/lib/logger.sh
+++ b/templates/bash-util/lib/logger.sh
@@ -10,7 +10,7 @@ export LOGGER_PRINT_FATAL="${LOGGER_ENABLE_FATAL:-true}"
 export LOGGER_PRINT_MESSAGE_ONLY="${LOGGER_PRINT_MESSAGE_ONLY:-false}"
 export LOGGER_HEADER_DATETIME="${LOGGER_HEADER_DATETIME:-datetime}"
 export LOGGER_HEADER_SERVER="${LOGGER_HEADER_SERVER:-server}"
-export LOGGER_HEADER_TARGET_TRIPLE="${LOGGER_HEADER_TARGET_TRIPLE:-target_triple}"
+export LOGGER_HEADER_TARGET_TUPLE="${LOGGER_HEADER_TARGET_TUPLE:-target_tuple}"
 export LOGGER_HEADER_LEVEL="${LOGGER_HEADER_LEVEL:-level}"
 export LOGGER_HEADER_MESSAGE="${LOGGER_HEADER_MESSAGE:-message}"
 
@@ -24,7 +24,7 @@ function logger::set_default_config() {
   export LOGGER_PRINT_FATAL='true'
   export LOGGER_HEADER_DATETIME='datetime'
   export LOGGER_HEADER_SERVER='server'
-  export LOGGER_HEADER_TARGET_TRIPLE='target_triple'
+  export LOGGER_HEADER_TARGET_TUPLE='target_tuple'
   export LOGGER_HEADER_LEVEL='level'
   export LOGGER_HEADER_MESSAGE='message'
 }
@@ -94,20 +94,20 @@ function logger::log_json() {
 
   local _datetime=''
   local _hostname=''
-  local _target_triple=''
+  local _target_tuple=''
   _datetime="$(core::rfc_3339)"
   _hostname="$(core::hostname)"
-  _target_triple="$(core::target_triple)"
+  _target_tuple="$(core::target_tuple)"
   local -r _datetime
   local -r _hostname
-  local -r _target_triple
+  local -r _target_tuple
 
   # json
   local -ra _log_json=(
     "{"
     "\"${LOGGER_HEADER_DATETIME:-datetime}\": \"${_datetime}\","
     "\"${LOGGER_HEADER_SERVER:-server}\": \"${_hostname}\","
-    "\"${LOGGER_HEADER_TARGET_TRIPLE:-target_triple}\": \"${_target_triple}\","
+    "\"${LOGGER_HEADER_TARGET_TUPLE:-target_tuple}\": \"${_target_tuple}\","
     "\"${LOGGER_HEADER_LEVEL:-level}\": \"${_logger_level}\","
     "\"${LOGGER_HEADER_MESSAGE:-message}\": \"${_message}\""
     "}"
@@ -130,19 +130,19 @@ function logger::log_tsv() {
 
   local _datetime=''
   local _hostname=''
-  local _target_triple=''
+  local _target_tuple=''
   _datetime="$(core::rfc_3339)"
   _hostname="$(core::hostname)"
-  _target_triple="$(core::target_triple)"
+  _target_tuple="$(core::target_tuple)"
   local -r _datetime
   local -r _hostname
-  local -r _target_triple
+  local -r _target_tuple
 
   # tsv
   local -ra _log_tsv=(
     "${_datetime}"
     "${_hostname}"
-    "${_target_triple}"
+    "${_target_tuple}"
     "${_logger_level}"
     "${_message}"
   )
@@ -164,19 +164,19 @@ function logger::log_csv() {
 
   local _datetime=''
   local _hostname=''
-  local _target_triple=''
+  local _target_tuple=''
   _datetime="$(core::rfc_3339)"
   _hostname="$(core::hostname)"
-  _target_triple="$(core::target_triple)"
+  _target_tuple="$(core::target_tuple)"
   local -r _datetime
   local -r _hostname
-  local -r _target_triple
+  local -r _target_tuple
 
   # csv
   local -ra _log_csv=(
     "${_datetime}"
     "${_hostname}"
-    "${_target_triple}"
+    "${_target_tuple}"
     "${_logger_level}"
     "${_message}"
   )
@@ -245,7 +245,7 @@ function logger::header_tsv() {
   local -ra _header_tsv=(
     "${LOGGER_HEADER_DATETIME}"
     "${LOGGER_HEADER_SERVER}"
-    "${LOGGER_HEADER_TARGET_TRIPLE}"
+    "${LOGGER_HEADER_TARGET_TUPLE}"
     "${LOGGER_HEADER_LEVEL}"
     "${LOGGER_HEADER_MESSAGE}"
   )
@@ -256,7 +256,7 @@ function logger::header_csv() {
   local -ra _header_csv=(
     "${LOGGER_HEADER_DATETIME}"
     "${LOGGER_HEADER_SERVER}"
-    "${LOGGER_HEADER_TARGET_TRIPLE}"
+    "${LOGGER_HEADER_TARGET_TUPLE}"
     "${LOGGER_HEADER_LEVEL}"
     "${LOGGER_HEADER_MESSAGE}"
   )

--- a/templates/bash-util/tests/core.bats
+++ b/templates/bash-util/tests/core.bats
@@ -34,9 +34,9 @@ teardown() {
   [[ "${output}" =~ ^[a-zA-Z0-9\.\_\-]+$ ]] || false
 }
 
-@test 'core::target_triple with success' {
+@test 'core::target_tuple with success' {
 
-  run core::target_triple
+  run core::target_tuple
   (( status == 0 )) || false
   [[ "${output}" =~ ^[_a-z0-9]+[-][-a-z0-9]+$ ]] || false
 }

--- a/templates/bash-util/tests/logger.bats
+++ b/templates/bash-util/tests/logger.bats
@@ -242,8 +242,8 @@ teardown() {
   run logger::log_tsv 'hoge'
 
   (( status == 0 )) || false
-  [[ "$(cut -f 4 <<< ${output})" = 'INFO' ]] || false
-  [[ "$(cut -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -f 4 <<< "${output}")" = 'INFO' ]] || false
+  [[ "$(cut -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::log_tsv with plane message and error level' {
@@ -253,8 +253,8 @@ teardown() {
   run logger::log_tsv 'hoge' 'error'
 
   (( status == 0 )) || false
-  [[ "$(cut -f 4 <<< ${output})" = 'ERROR' ]] || false
-  [[ "$(cut -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -f 4 <<< "${output}")" = 'ERROR' ]] || false
+  [[ "$(cut -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::log_tsv with plane message and unexpected level' {
@@ -273,8 +273,8 @@ teardown() {
   run logger::log_csv 'hoge'
 
   (( status == 0 )) || false
-  [[ "$(cut -d ',' -f 4 <<< ${output})" = 'INFO' ]] || false
-  [[ "$(cut -d ',' -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -d ',' -f 4 <<< "${output}")" = 'INFO' ]] || false
+  [[ "$(cut -d ',' -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::log_csv with plane message and error level' {
@@ -284,8 +284,8 @@ teardown() {
   run logger::log_csv 'hoge' 'error'
 
   (( status == 0 )) || false
-  [[ "$(cut -d ',' -f 4 <<< ${output})" = 'ERROR' ]] || false
-  [[ "$(cut -d ',' -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -d ',' -f 4 <<< "${output}")" = 'ERROR' ]] || false
+  [[ "$(cut -d ',' -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::log_csv with plane message and unexpected level' {
@@ -340,8 +340,8 @@ teardown() {
   run logger::log 'hoge' 'error' 'tsv'
 
   (( status == 0)) || false
-  [[ "$(cut -f 4 <<< ${output})" = 'ERROR' ]] || false
-  [[ "$(cut -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -f 4 <<< "${output}")" = 'ERROR' ]] || false
+  [[ "$(cut -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::log with csv format' {
@@ -351,8 +351,8 @@ teardown() {
   run logger::log 'hoge' 'error' 'csv'
 
   (( status == 0)) || false
-  [[ "$(cut -d ',' -f 4 <<< ${output})" = 'ERROR' ]] || false
-  [[ "$(cut -d ',' -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -d ',' -f 4 <<< "${output}")" = 'ERROR' ]] || false
+  [[ "$(cut -d ',' -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::log with unexpected format' {
@@ -392,8 +392,8 @@ teardown() {
   run logger::trace 'hoge' 'tsv'
 
   (( status == 0 )) || false
-  [[ "$(cut -f 4 <<< ${output})" = 'TRACE' ]] || false
-  [[ "$(cut -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -f 4 <<< "${output}")" = 'TRACE' ]] || false
+  [[ "$(cut -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::trace with csv format' {
@@ -402,8 +402,8 @@ teardown() {
   run logger::trace 'hoge' 'csv'
 
   (( status == 0 )) || false
-  [[ "$(cut -d ',' -f 4 <<< ${output})" = 'TRACE' ]] || false
-  [[ "$(cut -d ',' -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -d ',' -f 4 <<< "${output}")" = 'TRACE' ]] || false
+  [[ "$(cut -d ',' -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::trace with unexpected format' {
@@ -434,8 +434,8 @@ teardown() {
   run logger::debug 'hoge' 'tsv'
 
   (( status == 0 )) || false
-  [[ "$(cut -f 4 <<< ${output})" = 'DEBUG' ]] || false
-  [[ "$(cut -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -f 4 <<< "${output}")" = 'DEBUG' ]] || false
+  [[ "$(cut -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::debug with csv format' {
@@ -445,8 +445,8 @@ teardown() {
   run logger::debug 'hoge' 'csv'
 
   (( status == 0 )) || false
-  [[ "$(cut -d ',' -f 4 <<< ${output})" = 'DEBUG' ]] || false
-  [[ "$(cut -d ',' -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -d ',' -f 4 <<< "${output}")" = 'DEBUG' ]] || false
+  [[ "$(cut -d ',' -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::debug with unexpected format' {
@@ -478,8 +478,8 @@ teardown() {
   run logger::info 'hoge' 'tsv'
 
   (( status == 0 )) || false
-  [[ "$(cut -f 4 <<< ${output})" = 'INFO' ]] || false
-  [[ "$(cut -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -f 4 <<< "${output}")" = 'INFO' ]] || false
+  [[ "$(cut -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::info with csv format' {
@@ -489,8 +489,8 @@ teardown() {
   run logger::info 'hoge' 'csv'
 
   (( status == 0 )) || false
-  [[ "$(cut -d ',' -f 4 <<< ${output})" = 'INFO' ]] || false
-  [[ "$(cut -d ',' -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -d ',' -f 4 <<< "${output}")" = 'INFO' ]] || false
+  [[ "$(cut -d ',' -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::info with unexpected format' {
@@ -522,8 +522,8 @@ teardown() {
   run logger::warn 'hoge' 'tsv'
 
   (( status == 0 )) || false
-  [[ "$(cut -f 4 <<< ${output})" = 'WARN' ]] || false
-  [[ "$(cut -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -f 4 <<< "${output}")" = 'WARN' ]] || false
+  [[ "$(cut -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::warn with csv format' {
@@ -533,8 +533,8 @@ teardown() {
   run logger::warn 'hoge' 'csv'
 
   (( status == 0 )) || false
-  [[ "$(cut -d ',' -f 4 <<< ${output})" = 'WARN' ]] || false
-  [[ "$(cut -d ',' -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -d ',' -f 4 <<< "${output}")" = 'WARN' ]] || false
+  [[ "$(cut -d ',' -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::warn with unexpected format' {
@@ -566,8 +566,8 @@ teardown() {
   run logger::error 'hoge' 'tsv'
 
   (( status == 0 )) || false
-  [[ "$(cut -f 4 <<< ${output})" = 'ERROR' ]] || false
-  [[ "$(cut -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -f 4 <<< "${output}")" = 'ERROR' ]] || false
+  [[ "$(cut -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::error with csv format' {
@@ -577,8 +577,8 @@ teardown() {
   run logger::error 'hoge' 'csv'
 
   (( status == 0 )) || false
-  [[ "$(cut -d ',' -f 4 <<< ${output})" = 'ERROR' ]] || false
-  [[ "$(cut -d ',' -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -d ',' -f 4 <<< "${output}")" = 'ERROR' ]] || false
+  [[ "$(cut -d ',' -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::error with unexpected format' {
@@ -610,8 +610,8 @@ teardown() {
   run logger::fatal 'hoge' 'tsv'
 
   (( status == 0 )) || false
-  [[ "$(cut -f 4 <<< ${output})" = 'FATAL' ]] || false
-  [[ "$(cut -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -f 4 <<< "${output}")" = 'FATAL' ]] || false
+  [[ "$(cut -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::fatal with csv format' {
@@ -621,8 +621,8 @@ teardown() {
   run logger::fatal 'hoge' 'csv'
 
   (( status == 0 )) || false
-  [[ "$(cut -d ',' -f 4 <<< ${output})" = 'FATAL' ]] || false
-  [[ "$(cut -d ',' -f 5 <<< ${output})" = 'hoge' ]] || false
+  [[ "$(cut -d ',' -f 4 <<< "${output}")" = 'FATAL' ]] || false
+  [[ "$(cut -d ',' -f 5 <<< "${output}")" = 'hoge' ]] || false
 }
 
 @test 'logger::fatal with unexpected format' {
@@ -637,7 +637,7 @@ teardown() {
 @test 'logger::header_tsv' {
 
   logger::set_default_config
-  local -r _expected_header='datetime\tserver\ttarget_triple\tlevel\tmessage'
+  local -r _expected_header='datetime\tserver\ttarget_tuple\tlevel\tmessage'
   run logger::header_tsv
   (( status == 0 )) || false
   [[ "${output}" = "$(echo -e "${_expected_header}")" ]] || false
@@ -646,7 +646,7 @@ teardown() {
 @test 'logger::header_csv' {
 
   logger::set_default_config
-  local -r _expected_header='datetime,server,target_triple,level,message'
+  local -r _expected_header='datetime,server,target_tuple,level,message'
 
   run logger::header_csv
 

--- a/templates/bash-util/tests/validator.bats
+++ b/templates/bash-util/tests/validator.bats
@@ -386,7 +386,7 @@ teardown() {
   [[ "${output}" = '' ]] || false
 }
 
-@test 'valodator::is_interger with positive single digit' {
+@test 'validator::is_interger with positive single digit' {
 
   run validator::is_interger '1'
 
@@ -394,7 +394,7 @@ teardown() {
   [[ "${output}" = '' ]] || false
 }
 
-@test 'valodator::is_interger with negative single digit' {
+@test 'validator::is_interger with negative single digit' {
 
   command -v jq &>/dev/null || false
   run validator::is_interger '-1'
@@ -403,7 +403,7 @@ teardown() {
   [[ "${output}" = '' ]] || false
 }
 
-@test 'valodator::is_interger with positive multi digit' {
+@test 'validator::is_interger with positive multi digit' {
 
   run validator::is_interger '1234567890'
 
@@ -411,7 +411,7 @@ teardown() {
   [[ "${output}" = '' ]] || false
 }
 
-@test 'valodator::is_interger with negative multi digit' {
+@test 'validator::is_interger with negative multi digit' {
 
   run validator::is_interger '-1234567890'
 
@@ -419,7 +419,7 @@ teardown() {
   [[ "${output}" = '' ]] || false
 }
 
-@test 'valodator::is_interger with positive zero' {
+@test 'validator::is_interger with positive zero' {
 
   command -v jq &>/dev/null || false
   run validator::is_interger '+0'
@@ -428,7 +428,7 @@ teardown() {
   [[ "$(jq -rc '.level' <<< "${output}")" = 'ERROR' ]] || false
 }
 
-@test 'valodator::is_interger with negative zero' {
+@test 'validator::is_interger with negative zero' {
 
   run validator::is_interger '-0'
 
@@ -436,7 +436,7 @@ teardown() {
   [[ "${output}" = '' ]] || false
 }
 
-@test 'valodator::is_interger with warn level' {
+@test 'validator::is_interger with warn level' {
 
   command -v jq &>/dev/null || false
   run validator::is_interger 'hoge' 'warn'
@@ -445,7 +445,7 @@ teardown() {
   [[ "$(jq -rc '.level' <<< "${output}")" = 'WARN' ]] || false
 }
 
-@test 'valodator::is_interger with warn level and csv format' {
+@test 'validator::is_interger with warn level and csv format' {
 
   run validator::is_interger 'hoge' 'warn' 'csv'
 
@@ -453,7 +453,7 @@ teardown() {
   [[ "$(cut -d ',' -f 4 <<< ${output})" = 'WARN' ]] || false
 }
 
-@test 'valodator::is_positive_integer with zero' {
+@test 'validator::is_positive_integer with zero' {
 
   run validator::is_positive_integer '0'
 
@@ -461,7 +461,7 @@ teardown() {
   [[ "${output}" = '' ]] || false
 }
 
-@test 'valodator::is_positive_integer with positive single digit' {
+@test 'validator::is_positive_integer with positive single digit' {
 
   run validator::is_positive_integer '1'
 
@@ -469,7 +469,7 @@ teardown() {
   [[ "${output}" = '' ]] || false
 }
 
-@test 'valodator::is_positive_integer with positive multi digit' {
+@test 'validator::is_positive_integer with positive multi digit' {
 
   run validator::is_positive_integer '1234567890'
 
@@ -477,7 +477,7 @@ teardown() {
   [[ "${output}" = '' ]] || false
 }
 
-@test 'valodator::is_positive_integer with positive zero' {
+@test 'validator::is_positive_integer with positive zero' {
 
   command -v jq &>/dev/null || false
   run validator::is_positive_integer '+0'
@@ -495,7 +495,7 @@ teardown() {
   [[ "$(jq -rc '.level' <<< "${output}")" = 'ERROR' ]] || false
 }
 
-@test 'valodator::is_positive_integer with negative single digit' {
+@test 'validator::is_positive_integer with negative single digit' {
 
   command -v jq &>/dev/null || false
   run validator::is_positive_integer '-1'
@@ -504,7 +504,7 @@ teardown() {
   [[ "$(jq -rc '.level' <<< "${output}")" = 'ERROR' ]] || false
 }
 
-@test 'valodator::is_positive_integer with negative multi digit' {
+@test 'validator::is_positive_integer with negative multi digit' {
 
   command -v jq &>/dev/null || false
   run validator::is_positive_integer '-1234567890'
@@ -513,7 +513,7 @@ teardown() {
   [[ "$(jq -rc '.level' <<< "${output}")" = 'ERROR' ]] || false
 }
 
-@test 'valodator::is_positive_integer with warn level' {
+@test 'validator::is_positive_integer with warn level' {
 
   command -v jq &>/dev/null || false
   run validator::is_positive_integer 'hoge' 'warn'
@@ -522,7 +522,7 @@ teardown() {
   [[ "$(jq -rc '.level' <<< "${output}")" = 'WARN' ]] || false
 }
 
-@test 'valodator::is_positive_integer with warn level and csv format' {
+@test 'validator::is_positive_integer with warn level and csv format' {
 
   run validator::is_positive_integer 'hoge' 'warn' 'csv'
 
@@ -530,7 +530,7 @@ teardown() {
   [[ "$(cut -d ',' -f 4 <<< ${output})" = 'WARN' ]] || false
 }
 
-@test 'valodator::is_negative_integer with zero' {
+@test 'validator::is_negative_integer with zero' {
 
   command -v jq &>/dev/null || false
   run validator::is_negative_integer '0'
@@ -539,7 +539,7 @@ teardown() {
   [[ "$(jq -rc '.level' <<< "${output}")" = 'ERROR' ]] || false
 }
 
-@test 'valodator::is_negative_integer with positive single digit' {
+@test 'validator::is_negative_integer with positive single digit' {
 
   command -v jq &>/dev/null || false
   run validator::is_negative_integer '1'
@@ -548,7 +548,7 @@ teardown() {
   [[ "$(jq -rc '.level' <<< "${output}")" = 'ERROR' ]] || false
 }
 
-@test 'valodator::is_negative_integer with positive multi digit' {
+@test 'validator::is_negative_integer with positive multi digit' {
 
   command -v jq &>/dev/null || false
   run validator::is_negative_integer '1234567890'
@@ -557,7 +557,7 @@ teardown() {
   [[ "$(jq -rc '.level' <<< "${output}")" = 'ERROR' ]] || false
 }
 
-@test 'valodator::is_negative_integer with positive zero' {
+@test 'validator::is_negative_integer with positive zero' {
 
   command -v jq &>/dev/null || false
   run validator::is_negative_integer '+0'
@@ -574,7 +574,7 @@ teardown() {
   [[ "${output}" = '' ]] || false
 }
 
-@test 'valodator::is_negative_integer with negative single digit' {
+@test 'validator::is_negative_integer with negative single digit' {
 
   run validator::is_negative_integer '-1'
 
@@ -582,7 +582,7 @@ teardown() {
   [[ "${output}" = '' ]] || false
 }
 
-@test 'valodator::is_negative_integer with negative multi digit' {
+@test 'validator::is_negative_integer with negative multi digit' {
 
   run validator::is_negative_integer '-1234567890'
 

--- a/workspaces/multipass/launch
+++ b/workspaces/multipass/launch
@@ -199,7 +199,7 @@ function check_exists_instance() {
 }
 
 function generate_ssh_comment() {
-  echo "$(core::rfc_3339)-$(core::target_triple)-$(uname -n)"
+  echo "$(core::rfc_3339)-$(core::target_tuple)-$(uname -n)"
 }
 
 function get_authorized_key() {


### PR DESCRIPTION
- [target-tuple](https://aznhe21.hatenablog.com/entry/2025/01/10/rust-1.84#target-triple%E3%82%92target-tuple%E3%81%A8%E5%91%BC%E3%81%B6%E3%82%88%E3%81%86%E3%81%AB%E3%81%AA%E3%81%A3%E3%81%9F)
- bats テストについてのバグ・タイポを修正